### PR TITLE
Added option to skip loading or storing cache trough the events

### DIFF
--- a/src/StrokerCache/Event/CacheEvent.php
+++ b/src/StrokerCache/Event/CacheEvent.php
@@ -21,6 +21,11 @@ class CacheEvent extends Event
     protected $cacheKey;
 
     /**
+     * @var bool
+     */
+    protected $abort = false;
+
+    /**
      * @return string
      */
     public function getCacheKey()
@@ -34,5 +39,23 @@ class CacheEvent extends Event
     public function setCacheKey($cacheKey)
     {
         $this->cacheKey = $cacheKey;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getAbort()
+    {
+        return $this->abort;
+    }
+
+    /**
+     * @param boolean $abort
+     * @return CacheEvent
+     */
+    public function setAbort($abort)
+    {
+        $this->abort = (boolean) $abort;
+        return $this;
     }
 }


### PR DESCRIPTION
With these changes you are able to skip loading or storing the data in cache. This is useful if you dont want to cache when a user is logged in for example.

I know I should add unit tests but I really have no time to make them.
