### PR TITLE
Composer should use a tagged version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation of StrokerCache uses composer. For composer documentation, please r
      ```json
      {
          "require": {
-             "stroker/cache": "*"
+             "stroker/cache": "0.2.*"
          }
      }
      ```


### PR DESCRIPTION
In case of an unstable/untested master branch, using a tagged version should be the default behaviour.
