### PR TITLE
EVENT_SAVE does not have cache key set

### DIFF
--- a/src/Service/CacheService.php
+++ b/src/Service/CacheService.php
@@ -103,7 +103,10 @@ class CacheService
 
         $this->getCacheStorage()->setItem($id, $item);
 
-        $this->getEventManager()->triggerEvent($this->createCacheEvent(CacheEvent::EVENT_SAVE, $mvcEvent));
+        $cacheEvent = $this->createCacheEvent(CacheEvent::EVENT_SAVE, $mvcEvent);
+        $cacheEvent->setCacheKey($id);
+
+        $this->getEventManager()->triggerEvent($cacheEvent);
 
         $cacheStorage = $this->getCacheStorage();
         if ($cacheStorage instanceof TaggableInterface) {

--- a/tests/Service/CacheServiceTest.php
+++ b/tests/Service/CacheServiceTest.php
@@ -156,6 +156,25 @@ class CacheServiceTest extends \PHPUnit_Framework_TestCase
         $this->cacheService->save($this->getMvcEvent());
     }
 
+    public function testSaveEventHasCacheKey()
+    {
+        $response = $this->getMvcEvent()->getResponse();
+        $response->setContent('mockContent');
+
+        $this->cacheService->getEventManager()->attach(CacheEvent::EVENT_SHOULDCACHE, function () { return true; });
+        $this->cacheService->getEventManager()->attach(CacheEvent::EVENT_SAVE, function (CacheEvent $e) {
+            $this->assertNotNull($e->getCacheKey());
+        });
+
+        $this->storageMock
+            ->shouldReceive('setItem')
+            ->once()
+            ->with('/foo/bar', $response->getContent());
+
+        $this->cacheService->getOptions()->setCacheResponse(false);
+        $this->cacheService->save($this->getMvcEvent());
+    }
+
     public function testResponseIsCachedWhenOneListenerReturnsTrue()
     {
         $this->cacheService->getEventManager()->attach(CacheEvent::EVENT_SHOULDCACHE, function () { return false; });


### PR DESCRIPTION
documentation example:
````php
//...
$cacheService->getEventManager()->attach(CacheEvent::EVENT_SAVE, function (CacheEvent $e) use ($logger) {
    $logger->debug('Saving page to cache with ID: ' . $e->getCacheKey());
});
//...
````
this return null