### PR TITLE
Add ability to set custom cache tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,19 @@ The events are listed as constants in the [CacheEvent](https://github.com/bramst
 
 ### Examples
 
+Setting custom tags example
+
+```php
+public function onBootstrap(MvcEvent $e)
+{
+    $serviceManager = $e->getApplication()->getServiceManager();
+    $cacheService = $serviceManager->get('strokercache_service');
+    $cacheService->getEventManager()->attach(CacheEvent::EVENT_SAVE, function (CacheEvent $e) {
+        $e->setTags(['custom_tag']);
+    });
+}
+```
+
 Log to file whenever a page is written to the cache storage
 
 ```php

--- a/src/Event/CacheEvent.php
+++ b/src/Event/CacheEvent.php
@@ -27,6 +27,11 @@ class CacheEvent extends Event
     protected $mvcEvent;
 
     /**
+     * @var array
+     */
+    protected $tags = [];
+
+    /**
      * @return string
      */
     public function getCacheKey()
@@ -64,4 +69,19 @@ class CacheEvent extends Event
         return $this;
     }
 
+    /**
+     * @return array
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param array $tags
+     */
+    public function setTags(array $tags)
+    {
+        $this->tags = $tags;
+    }
 }

--- a/src/Service/CacheService.php
+++ b/src/Service/CacheService.php
@@ -107,7 +107,8 @@ class CacheService
 
         $cacheStorage = $this->getCacheStorage();
         if ($cacheStorage instanceof TaggableInterface) {
-            $cacheStorage->setTags($id, $this->getTags($mvcEvent));
+            $tags = array_unique(array_merge($this->getTags($mvcEvent), $cacheEvent->getTags()));
+            $cacheStorage->setTags($id, $tags);
         }
     }
 

--- a/src/Service/CacheService.php
+++ b/src/Service/CacheService.php
@@ -107,11 +107,8 @@ class CacheService
 
         $cacheStorage = $this->getCacheStorage();
         if ($cacheStorage instanceof TaggableInterface) {
-            $tags = array_map(
-                function ($tag) { return CacheService::TAG_PREFIX . $tag; },
-                array_unique(array_merge($this->getTags($mvcEvent), $cacheEvent->getTags()))
-            );
-            $cacheStorage->setTags($id, $tags);
+            $tags = array_unique(array_merge($this->getTags($mvcEvent), $cacheEvent->getTags()));
+            $cacheStorage->setTags($id, $this->prefixTags($tags));
         }
     }
 
@@ -148,10 +145,7 @@ class CacheService
         if (!$cacheStorage instanceof TaggableInterface) {
             throw new UnsupportedAdapterException('purging by tags is only supported on adapters implementing the TaggableInterface');
         }
-        $tags = array_map(
-            function ($tag) { return CacheService::TAG_PREFIX . $tag; },
-            $tags
-        );
+        $tags = $this->prefixTags($tags);
 
         return $cacheStorage->clearByTags($tags, $disjunction);
     }
@@ -177,6 +171,19 @@ class CacheService
         }
 
         return $tags;
+    }
+
+    /**
+     * @param array $tags
+     *
+     * @return array
+     */
+    private function prefixTags(array $tags)
+    {
+         return array_map(
+            function ($tag) { return CacheService::TAG_PREFIX . $tag; },
+            $tags
+        );
     }
 
     /**

--- a/src/Service/CacheService.php
+++ b/src/Service/CacheService.php
@@ -107,7 +107,10 @@ class CacheService
 
         $cacheStorage = $this->getCacheStorage();
         if ($cacheStorage instanceof TaggableInterface) {
-            $tags = array_unique(array_merge($this->getTags($mvcEvent), $cacheEvent->getTags()));
+            $tags = array_map(
+                function ($tag) { return CacheService::TAG_PREFIX . $tag; },
+                array_unique(array_merge($this->getTags($mvcEvent), $cacheEvent->getTags()))
+            );
             $cacheStorage->setTags($id, $tags);
         }
     }
@@ -163,13 +166,13 @@ class CacheService
     {
         $routeName = $event->getRouteMatch()->getMatchedRouteName();
         $tags = [
-            self::TAG_PREFIX . 'route_' . $routeName
+            'route_' . $routeName
         ];
         foreach ($event->getRouteMatch()->getParams() as $key => $value) {
             if ($key == 'controller') {
-                $tags[] = self::TAG_PREFIX . 'controller_' . $value;
+                $tags[] = 'controller_' . $value;
             } else {
-                $tags[] = self::TAG_PREFIX . 'param_' . $key . '_' . $value;
+                $tags[] = 'param_' . $key . '_' . $value;
             }
         }
 

--- a/tests/Service/CacheServiceTest.php
+++ b/tests/Service/CacheServiceTest.php
@@ -221,7 +221,7 @@ class CacheServiceTest extends \PHPUnit_Framework_TestCase
             'strokercache_route_home',
             'strokercache_controller_myTestController',
             'strokercache_param_someParam_someValue',
-            'custom_tag',
+            'strokercache_custom_tag',
         );
 
         $this->getMvcEvent()->getRouteMatch()->setMatchedRouteName('home');


### PR DESCRIPTION
Maybe not perfect solution but well at least will allow custom tags for example:
````php
$cacheService = $serviceManager->get('strokercache_service');
$cacheService->getEventManager()->attach(CacheEvent::EVENT_SAVE, function (CacheEvent $e) use ($cacheService) {
    $slug = $e->getMvcEvent()->getParam('article_slug');
    $article_tag = 'article_id' . $this->getIdBySlug($slug);
    $e->setTags([$article_tag]);
}, 1000);
````
I dont want this cached by slug because slug sometimes changes instead I want article id and now it will be possible